### PR TITLE
Add bloc selection dropdown for EU and NATO

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { IconContext } from 'react-icons'
 import { Dropdown } from 'react-bootstrap';
 import Map3 from './components/Map3'
 import CountriesDropdown from './components/Dropdown'
+import BlocDropdown from './components/BlocDropdown'
 import CountryDetails from './components/CountryDetails'
 import Filter from './components/Filter'
 import { countriesService } from './services/countriesService'
@@ -163,6 +164,7 @@ function App() {
       }}>
         <Filter countries={countries} showDetail={showDetail} setShowDetail={setShowDetail} selected={selected} setSelected={setSelected} dkd={deselectKeepDetails} />
         <CountriesDropdown countries={countries} setShowDetail={setShowDetail} blocs={blocs} selectOne={selectOne} selectMany={selectMany} user={user} />
+        <BlocDropdown countries={countries} selectMany={selectMany} />
         <Button hidden variant="warning" onClick={() => setLoggingIn(!loggingIn)}>Login</Button>
         <Button variant={mode ? "dark" : "light"} onClick={() => changeMode()}>{mode ? "🌙" : "☀️"}</Button>
         <Button href={"https://palcsta.github.io"}>{"🏠"}</Button>

--- a/src/components/BlocDropdown.js
+++ b/src/components/BlocDropdown.js
@@ -1,0 +1,52 @@
+import React from 'react'
+
+import DropdownButton from 'react-bootstrap/DropdownButton'
+import Dropdown from 'react-bootstrap/Dropdown'
+
+import '../styles/MapBottomButtons.css'
+
+const blocGroups = [
+  {
+    id: 'eu',
+    label: 'EU members',
+    countries: [
+      'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE',
+      'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT',
+      'RO', 'SK', 'SI', 'ES', 'SE'
+    ]
+  },
+  {
+    id: 'nato',
+    label: 'NATO members',
+    countries: [
+      'AL', 'BE', 'BG', 'CA', 'HR', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE',
+      'GR', 'HU', 'IS', 'IT', 'LV', 'LT', 'LU', 'ME', 'NL', 'MK', 'NO',
+      'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'TR', 'GB', 'US'
+    ]
+  }
+]
+
+const BlocDropdown = ({ countries, selectMany }) => {
+  const countryLookup = new Set(countries.map(country => country.cca2.toLowerCase()))
+
+  const toSelectableList = (codes) => (
+    codes
+      .map(code => code.toLowerCase())
+      .filter(code => countryLookup.has(code))
+  )
+
+  return (
+    <DropdownButton id="bloc-dropdown-button" title="Blocs">
+      {blocGroups.map(bloc => (
+        <Dropdown.Item
+          key={bloc.id}
+          onClick={() => selectMany(toSelectableList(bloc.countries))}
+        >
+          {bloc.label}
+        </Dropdown.Item>
+      ))}
+    </DropdownButton>
+  )
+}
+
+export default BlocDropdown


### PR DESCRIPTION
### Motivation
- Provide a quick toolbar control to select and highlight predefined blocs of countries (for example current EU and NATO members) similar to the existing continents Browse menu.

### Description
- Add `src/components/BlocDropdown.js`, which defines `blocGroups` for EU and NATO, maps alpha-2 codes to available countries and calls the existing `selectMany` handler; and wire the component into the top toolbar in `src/App.js` via `import BlocDropdown` and rendering `<BlocDropdown countries={countries} selectMany={selectMany} />`.

### Testing
- Started the app with `npm start`, the app compiled (with ESLint warnings) and a Playwright script visited `http://127.0.0.1:3000` and successfully captured a screenshot (`artifacts/bloc-dropdown.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987340d0e84832d9b8b519a3f0adb27)